### PR TITLE
meson: Add missing zlib dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ compiler = meson.get_compiler('cpp')
 thread_dep = dependency('threads')
 kiwixlib_dep = dependency('kiwix')
 microhttpd_dep = dependency('libmicrohttpd')
-
+z_dep = dependency('zlib')
 # Idealy we should not have more dependency, however :
 # We should declare we use ctpp2 in kiwixlib in the pkg-config file.
 # But there is no pkg-config file for ctpp2. Once one exists, no need to
@@ -34,7 +34,7 @@ else
   ctpp2_dep = declare_dependency(include_directories:ctpp2_include_path, dependencies:[ctpp2_lib])
 endif
 
-all_deps = [thread_dep, kiwixlib_dep, microhttpd_dep, ctpp2_dep]
+all_deps = [thread_dep, kiwixlib_dep, microhttpd_dep, ctpp2_dep, z_dep]
 
 #subdir('include')
 subdir('static')


### PR DESCRIPTION
I was running into the build error of:
```
[1/1] Linking target src/server/kiwix-serve
FAILED: src/server/kiwix-serve 
c++    -o src/server/kiwix-serve 'src/server/kiwix-serve@exe/static_server_server-resources.cpp.o' 'src/server/kiwix-serve@exe/kiwix-serve.cpp.o' '-Wl,--no-undefined' '-Wl,--as-needed' '-pthread' '-L/usr/local/lib/x86_64-linux-gnu' '-L/usr/local/lib' '-L/usr/local/lib/pugixml-1.8' '-lkiwix' '-lzim' '-llzma' '-licui18n' '-licuuc' '-licudata' '-lpugixml' '-lxapian' '-lmicrohttpd' '-lctpp2' 
/usr/bin/ld: src/server/kiwix-serve@exe/kiwix-serve.cpp.o: undefined reference to symbol 'compress'
//lib/x86_64-linux-gnu/libz.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

This change fixes that since it adds the proper linker flags for zlib.