### PR TITLE
Correctly set ProtocolPrefix and SearchProtocolPrefix for searcher.

### DIFF
--- a/src/searcher/kiwix-search.cpp
+++ b/src/searcher/kiwix-search.cpp
@@ -86,10 +86,11 @@ int main(int argc, char** argv)
   }
 
   if (reader) {
-    searcher = new kiwix::Searcher("", reader);
+    searcher = new kiwix::Searcher();
+    searcher->add_reader(reader, "");
   } else {
     try {
-      searcher = new kiwix::Searcher(zimPath, NULL);
+      searcher = new kiwix::Searcher(zimPath, NULL, "");
     } catch (...) {
       cerr << "Unable to search through zim '" << zimPath << "'." << endl;
       exit(1);

--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -949,10 +949,9 @@ int main(int argc, char** argv)
           searchers[humanReadableId] = searcher;
         } else if ( !indexPath.empty() ) {
           try {
-            kiwix::Searcher* searcher = new kiwix::Searcher(indexPath, reader);
+            kiwix::Searcher* searcher = new kiwix::Searcher(indexPath, reader, humanReadableId);
             searcher->setProtocolPrefix("/");
             searcher->setSearchProtocolPrefix("/search?");
-            searcher->setContentHumanReadableId(humanReadableId);
             searchers[humanReadableId] = searcher;
           } catch (...) {
             cerr << "Unable to open the search index '" << indexPath << "'."

--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -942,6 +942,8 @@ int main(int argc, char** argv)
 
         if ( reader->hasFulltextIndex()) {
           kiwix::Searcher* searcher = new kiwix::Searcher();
+          searcher->setProtocolPrefix("/");
+          searcher->setSearchProtocolPrefix("/search?");
           searcher->add_reader(reader, humanReadableId);
           globalSearcher->add_reader(reader, humanReadableId);
           searchers[humanReadableId] = searcher;


### PR DESCRIPTION
Default `protocolPrefix` for the kiwix-lib searcher is `zim:://`.
We have to change it to `/` for all searcher we create else the search's
results will have a `zim://...` url, which will obviously won't work.