### PR TITLE
Do not do globalSearch if the zim file has no full text index.

### DIFF
--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -956,7 +956,10 @@ int main(int argc, char** argv)
           } catch (...) {
             cerr << "Unable to open the search index '" << indexPath << "'."
                  << endl;
+            searchers[humanReadableId] = nullptr;
           }
+        } else {
+            searchers[humanReadableId] = nullptr;
         }
       }
     }


### PR DESCRIPTION
Global search is made only on the global task bar.
Task bar display in the article should provide full text search only
if the zim file has associated full text index.

This is done by having a `NULL` searcher. However, commit `558a0375`
return the globalSearcher if no searcher is associated to a zim.

This commit associate a `NULL` searcher to the zim, so we will not use
the globalSearcher.