### PR TITLE
do not cache results for searches from the welcome page

### DIFF
--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -452,6 +452,12 @@ static struct MHD_Response* handle_search(RequestContext* request_context)
       request_context->connection, MHD_GET_ARGUMENT_KIND, "pattern");
   std::string patternString
       = kiwix::urlDecode(pattern == NULL ? "" : string(pattern));
+
+  /* Search results for searches from the welcome page should not
+     be cached
+  */
+  bool cacheEnabled = !(request_context->searcher == globalSearcher);
+
   std::string patternCorrespondingUrl;
 
   /* Try first to load directly the article */
@@ -506,7 +512,7 @@ static struct MHD_Response* handle_search(RequestContext* request_context)
                         httpRedirection,
                         mimeType,
                         deflated,
-                        true);
+                        cacheEnabled);
 }
 
 static struct MHD_Response* handle_random(RequestContext* request_context)


### PR DESCRIPTION
We should not cache search results for searches done from the welcome page. When we add or remove zims from the library, search results for a given query should take these changes into account.

This pull request fixes the issue.