### PR TITLE
Escape '&' when it's require on kiwix-serve

### DIFF
--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -162,9 +162,7 @@ void introduceTaskbar(string& content, const string& humanReadableBookId)
     content = appendToFirstOccurence(
         content,
         "<head>",
-        replaceRegex(
-            RESOURCE::include_html_part, humanReadableBookId, "__CONTENT__")
-        + (noLibraryButtonFlag
+            RESOURCE::include_html_part + (noLibraryButtonFlag
             ? "<style>#kiwix_serve_taskbar_library_button { display: none }</style>"
             : "")
     );
@@ -183,6 +181,7 @@ void introduceTaskbar(string& content, const string& humanReadableBookId)
              "__CONTENT__"));
     }
     content = replaceRegex(content, rootLocation, "__ROOT_LOCATION__");
+    content = replaceRegex(content,replaceRegex(humanReadableBookId, "%26", "&"), "__CONTENT_ESCAPE__");
   }
   pthread_mutex_unlock(&regexLock);
 }

--- a/static/server/include.html.part
+++ b/static/server/include.html.part
@@ -8,7 +8,7 @@
   jk(function() {
   jk( "#kiwixsearchbox" ).autocomplete({
 
-  source: "__ROOT_LOCATION__/suggest?content=__CONTENT__",
+  source: "__ROOT_LOCATION__/suggest?content=__CONTENT_ESCAPE__",
   dataType: "json",
   cache: false,
 

--- a/static/server/taskbar.html.part
+++ b/static/server/taskbar.html.part
@@ -4,7 +4,7 @@
       <div class="kiwix_button_wrapper">
         <a id="kiwix_serve_taskbar_library_button" href="__ROOT_LOCATION__/"><button>Library</button></a>
         <a id="kiwix_serve_taskbar_home_button" href="__ROOT_LOCATION__/__CONTENT__/"><button>Home</button></a>
-        <a id="kiwix_serve_taskbar_random_button" href="__ROOT_LOCATION__/random?content=__CONTENT__"><button>Random</button></a>
+        <a id="kiwix_serve_taskbar_random_button" href="__ROOT_LOCATION__/random?content=__CONTENT_ESCAPE__"><button>Random</button></a>
       </div>
       <div class="kiwix_searchform">
         <form class="kiwixsearch" method="GET" action="__ROOT_LOCATION__/search" id="kiwixsearchform">


### PR DESCRIPTION
Char '&' is now escape has URL encoding when it is require (when the humanReadableBookId is pass has a argument of a url)
Fix issue #19 