### PR TITLE
Relative paths are relative to current directory not executable.

### DIFF
--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -920,9 +920,7 @@ int main(int argc, char** argv)
         try {
           string libraryPath
               = isRelativePath(*itr)
-                    ? computeAbsolutePath(removeLastPathElement(
-                                              getExecutablePath(), true, false),
-                                          *itr)
+                    ? computeAbsolutePath(getCurrentDirectory(), *itr)
                     : *itr;
           retVal = libraryManager.readFile(libraryPath, true);
         } catch (...) {


### PR DESCRIPTION
Almost nothing should be relative to the executable directory.
Content coming from the user should be relative to where the user
is (its working directory).

Fixes #70.