### PR TITLE
Fix crash

### DIFF
--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -724,15 +724,21 @@ static int accessHandlerCallback(void* cls,
                                  size_t* upload_data_size,
                                  void** ptr)
 {
+  if (isVerbose.load() ) {
+    printf("======================\n");
+    printf("Requesting : \n");
+    printf("full_url  : %s\n", url);
+  }
   RequestContext request(connection, rootLocation, url, method, version);
+
+  if (isVerbose.load() ) {
+    request.print_debug_info();
+  }
   /* Unexpected method */
   if (request.get_method() != RequestMethod::GET && request.get_method() != RequestMethod::POST) {
+    printf("Reject request because of unhandled request method.\n");
+    printf("----------------------\n");
     return MHD_NO;
-  }
-
-  if (isVerbose.load()) {
-    printf("======================\n");
-    request.print_debug_info();
   }
 
   /* Prepare the variables */

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -127,8 +127,6 @@ int RequestContext::fill_argument(void *__this, enum MHD_ValueKind kind,
 }
 
 void RequestContext::print_debug_info() {
-  printf("Requesting : \n");
-  printf("full_url  : %s\n", full_url.c_str());
   printf("method    : %s (%d)\n", method==RequestMethod::GET ? "GET" :
                                   method==RequestMethod::POST ? "POST" :
                                   "OTHER", method);

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -122,7 +122,7 @@ int RequestContext::fill_argument(void *__this, enum MHD_ValueKind kind,
                                    const char *key, const char* value)
 {
   RequestContext *_this = static_cast<RequestContext*>(__this);
-  _this->arguments[key] = value;
+  _this->arguments[key] = value == nullptr ? "" : value;
   return MHD_YES;
 }
 

--- a/src/server/request_context.cpp
+++ b/src/server/request_context.cpp
@@ -129,7 +129,7 @@ int RequestContext::fill_argument(void *__this, enum MHD_ValueKind kind,
 void RequestContext::print_debug_info() {
   printf("method    : %s (%d)\n", method==RequestMethod::GET ? "GET" :
                                   method==RequestMethod::POST ? "POST" :
-                                  "OTHER", method);
+                                  "OTHER", (int)method);
   printf("version   : %s\n", version.c_str());
   printf("headers   :\n");
   for (auto it=headers.begin(); it!=headers.end(); it++) {


### PR DESCRIPTION
Using the core-dump provided directly, it seems that #116 crash on `std::strlen` on a null pointer in `fill_argument` method.

This should fix the issue (hoping this is the sole bug)

Fix #116.