### PR TITLE
Correctly pre-increment the loopCounter.

### DIFF
--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -626,7 +626,7 @@ static struct MHD_Response* handle_content(RequestContext* request)
     if (found) {
       /* If redirect */
       unsigned int loopCounter = 0;
-      while (article.isRedirect() && loopCounter++ < 42) {
+      while (article.isRedirect() && ++loopCounter < 42) {
         article = article.getRedirectArticle();
       }
 


### PR DESCRIPTION
In case of infinit redirection, if we post-increment the loop counter,
we will exit the loop when loopCounter will be 42 and increment it.
So loop counter will be 43.

Let's pre-increment the counter to still compare with 42 (more consistancy)

Fix #168