### PR TITLE
Set rpath of the installed binaries.

### DIFF
--- a/src/installer/meson.build
+++ b/src/installer/meson.build
@@ -1,3 +1,4 @@
 executable('kiwix-install', ['kiwix-install.cpp'],
   dependencies:all_deps,
-  install:true)
+  install:true,
+  install_rpath: join_paths(get_option('prefix'), get_option('libdir')))

--- a/src/manager/meson.build
+++ b/src/manager/meson.build
@@ -1,3 +1,4 @@
 executable('kiwix-manage', ['kiwix-manage.cpp'],
   dependencies:all_deps,
-  install:true)
+  install:true,
+  install_rpath: join_paths(get_option('prefix'), get_option('libdir')))

--- a/src/reader/meson.build
+++ b/src/reader/meson.build
@@ -1,3 +1,4 @@
 executable('kiwix-read', ['kiwix-read.cpp'],
   dependencies:all_deps,
-  install:true)
+  install:true,
+  install_rpath: join_paths(get_option('prefix'), get_option('libdir')))

--- a/src/searcher/meson.build
+++ b/src/searcher/meson.build
@@ -1,3 +1,4 @@
 executable('kiwix-search', ['kiwix-search.cpp'],
   dependencies:all_deps,
-  install:true)
+  install:true,
+  install_rpath: join_paths(get_option('prefix'), get_option('libdir')))

--- a/src/server/meson.build
+++ b/src/server/meson.build
@@ -4,4 +4,5 @@ sources += server_resources
 
 executable('kiwix-serve', sources,
   dependencies:all_deps,
-  install:true)
+  install:true,
+  install_rpath: join_paths(get_option('prefix'), get_option('libdir')))


### PR DESCRIPTION
Let's set RPATH of installed binaries, this way, we will be able to
run dynamically linked binaries without changing LD_LIBRARY_PATH.