### PR TITLE
fix static resources on home page

### DIFF
--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -161,9 +161,9 @@ void introduceTaskbar(string& content, const string& humanReadableBookId)
              humanReadableBookId,
              "__CONTENT__"));
     }
-    content = replaceRegex(content, rootLocation, "__ROOT_LOCATION__");
     content = replaceRegex(content, replaceRegex(humanReadableBookId, "%26", "&"), "__CONTENT_ESCAPED__");
   }
+  content = replaceRegex(content, rootLocation, "__ROOT_LOCATION__");
   pthread_mutex_unlock(&regexLock);
 }
 

--- a/static/server/global_taskbar.html.part
+++ b/static/server/global_taskbar.html.part
@@ -2,7 +2,7 @@
   <span id="kiwixtoolbar" class="ui-widget-header">
     <div class="kiwix_centered">
       <div class="kiwix_searchform">
-        <form class="kiwixsearch" method="GET" action="search" id="kiwixsearchform">
+        <form class="kiwixsearch" method="GET" action="__ROOT_LOCATION__/search" id="kiwixsearchform">
           <input autocomplete="off" class="ui-autocomplete-input" id="kiwixsearchbox" name="pattern" type="text">
           <input type="submit" value="Search">
         </form>

--- a/static/server/global_taskbar.html.part
+++ b/static/server/global_taskbar.html.part
@@ -2,7 +2,7 @@
   <span id="kiwixtoolbar" class="ui-widget-header">
     <div class="kiwix_centered">
       <div class="kiwix_searchform">
-        <form class="kiwixsearch" method="GET" action="__ROOT_LOCATION__/search" id="kiwixsearchform">
+        <form class="kiwixsearch" method="GET" action="search" id="kiwixsearchform">
           <input autocomplete="off" class="ui-autocomplete-input" id="kiwixsearchbox" name="pattern" type="text">
           <input type="submit" value="Search">
         </form>

--- a/static/server/home.html.tmpl
+++ b/static/server/home.html.tmpl
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <title>Welcome to Kiwix Server</title>
-  <script type="text/javascript" src="__ROOT_LOCATION__/skin/jquery-ui/external/jquery/jquery.js"></script>
-  <script type="text/javascript" src="__ROOT_LOCATION__/skin/jquery-ui/jquery-ui.min.js"></script>
-  <link type="text/css" href="__ROOT_LOCATION__/skin/jquery-ui/jquery-ui.min.css" rel="Stylesheet" />
-  <link type="text/css" href="__ROOT_LOCATION__/skin/jquery-ui/jquery-ui.theme.min.css" rel="Stylesheet" />
+  <script type="text/javascript" src="skin/jquery-ui/external/jquery/jquery.js"></script>
+  <script type="text/javascript" src="skin/jquery-ui/jquery-ui.min.js"></script>
+  <link type="text/css" href="skin/jquery-ui/jquery-ui.min.css" rel="Stylesheet" />
+  <link type="text/css" href="skin/jquery-ui/jquery-ui.theme.min.css" rel="Stylesheet" />
   <style>
     	body {
 	        background:

--- a/static/server/home.html.tmpl
+++ b/static/server/home.html.tmpl
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <title>Welcome to Kiwix Server</title>
-  <script type="text/javascript" src="skin/jquery-ui/external/jquery/jquery.js"></script>
-  <script type="text/javascript" src="skin/jquery-ui/jquery-ui.min.js"></script>
-  <link type="text/css" href="skin/jquery-ui/jquery-ui.min.css" rel="Stylesheet" />
-  <link type="text/css" href="skin/jquery-ui/jquery-ui.theme.min.css" rel="Stylesheet" />
+  <script type="text/javascript" src="__ROOT_LOCATION__/skin/jquery-ui/external/jquery/jquery.js"></script>
+  <script type="text/javascript" src="__ROOT_LOCATION__/skin/jquery-ui/jquery-ui.min.js"></script>
+  <link type="text/css" href="__ROOT_LOCATION__/skin/jquery-ui/jquery-ui.min.css" rel="Stylesheet" />
+  <link type="text/css" href="__ROOT_LOCATION__/skin/jquery-ui/jquery-ui.theme.min.css" rel="Stylesheet" />
   <style>
     	body {
 	        background:


### PR DESCRIPTION
The static resources on the homepage were being returned from a wrong url of the format:

`http://IP/kiwix/___ROOT_LOCATION___/some_static_resource ...` where kiwix = urlRootLocation

Looks like replacement for ___ROOT_LOCATION___ is nolonger needed for the home page

