### PR TITLE
Fix #211: getMimeTypeForFile does not handle files without extensions correctly

### DIFF
--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -130,7 +130,7 @@ get_from_humanReadableBookId(const std::string& humanReadableBookId) {
 static std::string getMimeTypeForFile(const std::string& filename)
 {
   std::string mimeType = "text/plain";
-  unsigned int pos = filename.find_last_of(".");
+  auto pos = filename.find_last_of(".");
 
   if (pos != std::string::npos) {
     std::string extension = filename.substr(pos + 1);


### PR DESCRIPTION
Use `size_t` instead of `unsigned int` to ensure proper size on 64-bit platforms