### PR TITLE
Fix #213: sockaddr_in is undefined when compiling on FreeBSD

### DIFF
--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -79,6 +79,7 @@ extern "C" {
 #include <netdb.h>
 #include <stdint.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
Make sure that <netinet/in.h> is included as per POSIX spec.