### PR TITLE
Do not use this_thread::sleep or thread::hardware_concurrency.

### DIFF
--- a/src/manager/kiwix-manage.cpp
+++ b/src/manager/kiwix-manage.cpp
@@ -28,8 +28,7 @@
 #include <cstdlib>
 #include <iostream>
 
-#include <thread>
-#include <chrono>
+#include <time.h>
 
 using namespace std;
 
@@ -240,7 +239,8 @@ bool handle_download(kiwix::Library* library, const std::string& libraryPath,
       exitCode = true;
       break;
     }
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    struct timespec wait = {1, 0};
+    nanosleep(&wait, nullptr);
   }
 
   downloader.close();

--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -67,7 +67,6 @@ extern "C" {
 #include <iostream>
 #include <map>
 #include <sstream>
-#include <thread>
 #include <string>
 #include <vector>
 #include "server-resources.h"
@@ -949,7 +948,7 @@ int main(int argc, char** argv)
   int libraryFlag = false;
   string PPIDString;
   unsigned int PPID = 0;
-  unsigned int nb_threads = std::thread::hardware_concurrency();
+  unsigned int nb_threads = 4;
 
   static struct option long_options[]
       = {{"daemon", no_argument, 0, 'd'},


### PR DESCRIPTION
Mingw doesn't implement them. So, we should not use it.
I suppose that it was working before because mingw package for debian trusty
simply no provides a "thread" header.
We may face to include the native "thread" header.