### PR TITLE
Correctly set the zimPathToSave if there are several zim file to add.

### DIFF
--- a/src/manager/kiwix-manage.cpp
+++ b/src/manager/kiwix-manage.cpp
@@ -173,8 +173,8 @@ bool handle_add(kiwix::Library* library, const std::string& libraryPath,
   for(auto i=optind; i<argc; i++) {
     std::string zimPath = argv[i];
     if (!zimPath.empty()) {
-      zimPathToSave = zimPathToSave == "." ? zimPath : zimPathToSave;
-      manager.addBookFromPathAndGetId(zimPath, zimPathToSave, url, false);
+      auto _zimPathToSave = zimPathToSave == "." ? zimPath : zimPathToSave;
+      manager.addBookFromPathAndGetId(zimPath, _zimPathToSave, url, false);
     } else {
       std::cerr << "Invalid zim file path" << std::endl;
       resultCode = 1;


### PR DESCRIPTION
The variable `zimPathToSave` is used to store the option passed by the
user.
If we reuse this variable to store the real path to use for the first
zim file, then we will mess the path to save of other zim files.

Let's use a local variable here.

Fix #288