### PR TITLE
Fixed typo in meson build script

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ if static_linkage
   add_global_link_arguments('-static-libstdc++', '--static', language:'cpp')
 endif
 
-thread_dep = depenidency('threads')
+thread_dep = dependency('threads')
 kiwixlib_dep = dependency('kiwix', version:'>=9.1.0', static:static_linkage)
 microhttpd_dep = dependency('libmicrohttpd', static:static_linkage)
 z_dep = dependency('zlib', static:static_linkage)


### PR DESCRIPTION
Fixed build after 6ba6046850eb92f6d23408f38a5de93c970720a1 commit.