### PR TITLE
Include missing "windows.h"

### DIFF
--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -23,7 +23,9 @@
 #include <kiwix/name_mapper.h>
 #include <kiwix/tools/otherTools.h>
 
-#ifndef _WIN32
+#ifdef _WIN32
+# include <windows.h>
+#else
 # include <unistd.h>
 #endif
 


### PR DESCRIPTION
Now that libzim doesn't inculde "windows.h" in its public headers it fails
if we don't include it.