### PR TITLE
Add support for ARM in Docker

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,10 +1,17 @@
-FROM alpine:latest
+# declare build option ARCH
+ARG ARCH=
+# download ARCH-specific base image if specified
+FROM ${ARCH}alpine:3
+# decide which kiwix arch to download later (`armhf` for all arm* and x86_64 otherwise)
+ARG ARCH
+RUN if [ $(echo $ARCH | cut -c 1-3) = "arm" ] ; then echo "armhf" > /etc/kiwix_arch ; else echo "x86_64" > /etc/kiwix_arch ; fi
 LABEL maintainer Emmanuel Engelhart <kelson@kiwix.org>
 
 # Install kiwix-serve
+ARG RELEASE_ARCH="x86_64"
 WORKDIR /
 RUN apk add --no-cache curl bzip2
-RUN curl -kL https://download.kiwix.org/release/kiwix-tools/kiwix-tools_linux-x86_64.tar.gz | tar -xz && \
+RUN curl -kL https://download.kiwix.org/release/kiwix-tools/kiwix-tools_linux-$(cat /etc/kiwix_arch).tar.gz | tar -xz && \
     mv kiwix-tools*/kiwix-serve /usr/local/bin && \
     rm -r kiwix-tools*
 


### PR DESCRIPTION
Alternative impl of #404 

Usage would be

```sh
# for an arm build
docker build . -t kiwix/kiwix-serve:latest --build-arg ARCH="arm32v7a/"
docker build . -t kiwix/kiwix-serve:latest --build-arg ARCH="amd64"
```

Yes, the arg needs to end with a slash, that's what makes it work if you don't set anything. This will download the `armhf` release of kiwix-tools for any `ARCH` starting with `arm`. All others would use the `x68_64` version.