### PR TITLE
CI built docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,12 @@
 name: Docker
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
+    inputs:
+      version:
+        description: Specific version to build (overrides on-master and tag-pattern)
+        required: false
+        default: ''
 
 jobs:
   build-and-push:
@@ -11,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: openzim/docker-publish-action@v4
+      - uses: openzim/docker-publish-action@v5
         with:
           image-name: kiwix/kiwix-tools
           credentials: |
@@ -20,17 +23,17 @@ jobs:
             GHCRIO_USERNAME=${{ secrets.GHCR_USERNAME }}
             GHCRIO_TOKEN=${{ secrets.GHCR_TOKEN }}
           context: docker
-          tag-pattern: /^([0-9.]+)$/
           latest-on-tag: true
           build-args:
-            VERSION={version}
+            VERSION={tag}
           platforms: |
             linux/amd64
             linux/arm/v7
             linux/arm64
           restrict-to: kiwix/kiwix-tools
+          manual-tag: ${{ github.event.inputs.version }}
 
-      - uses: openzim/docker-publish-action@v4
+      - uses: openzim/docker-publish-action@v5
         with:
           image-name: kiwix/kiwix-serve
           credentials: |
@@ -42,9 +45,10 @@ jobs:
           tag-pattern: /^([0-9.]+)$/
           latest-on-tag: true
           build-args:
-            VERSION={version}
+            VERSION={tag}
           platforms: |
             linux/amd64
             linux/arm/v7
             linux/arm64
           restrict-to: kiwix/kiwix-tools
+          manual-tag: ${{ github.event.inputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,50 @@
+name: Docker
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    name: Deploy Docker Image
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: openzim/docker-publish-action@v4
+        with:
+          image-name: kiwix/kiwix-tools
+          credentials: |
+            DOCKERIO_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
+            DOCKERIO_TOKEN=${{ secrets.DOCKERHUB_PASSWORD }}
+            GHCRIO_USERNAME=${{ secrets.GHCR_USERNAME }}
+            GHCRIO_TOKEN=${{ secrets.GHCR_TOKEN }}
+          context: docker
+          tag-pattern: /^([0-9.]+)$/
+          latest-on-tag: true
+          build-args:
+            VERSION={version}
+          platforms: |
+            linux/amd64
+            linux/arm/v7
+            linux/arm64
+          restrict-to: kiwix/kiwix-tools
+
+      - uses: openzim/docker-publish-action@v4
+        with:
+          image-name: kiwix/kiwix-serve
+          credentials: |
+            DOCKERIO_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
+            DOCKERIO_TOKEN=${{ secrets.DOCKERHUB_PASSWORD }}
+            GHCRIO_USERNAME=${{ secrets.GHCR_USERNAME }}
+            GHCRIO_TOKEN=${{ secrets.GHCR_TOKEN }}
+          context: docker/server
+          tag-pattern: /^([0-9.]+)$/
+          latest-on-tag: true
+          build-args:
+            VERSION={version}
+          platforms: |
+            linux/amd64
+            linux/arm/v7
+            linux/arm64
+          restrict-to: kiwix/kiwix-tools

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,33 @@
+# declare build option ARCH if not using buildx
+ARG ARCH=
+# declare version to build image for
+ARG VERSION=
+
+# alpine is a multi-arch image
+FROM alpine:3
+LABEL org.opencontainers.image.source https://github.com/openzim/kiwix-tools
+
+# TARGETARCH is injected by buildx
+ARG TARGETARCH
+ARG VERSION
+ARG ARCH
+
+# if we had no TARGETARCH (not buildx), use --build-arg ARCH. default to amd64
+RUN echo "amd64" > /etc/docker_arch
+RUN if [ ! -z "$ARCH" ] ; then echo "$ARCH" > /etc/docker_arch ; fi
+RUN if [ ! -z "$TARGETARCH" ] ; then echo "$TARGETARCH" > /etc/docker_arch ; fi
+
+# decide which kiwix arch to download later (`armhf` for all arm* and x86_64 otherwise)
+RUN if [ $(cut -c 1-3 /etc/docker_arch) = "arm" ] ; then echo "armhf" > /etc/kiwix_arch ; else echo "x86_64" > /etc/kiwix_arch ; fi
+
+# Install kiwix-tools
+RUN url="http://mirror.download.kiwix.org/release/kiwix-tools/kiwix-tools_linux-$(cat /etc/kiwix_arch)-$VERSION.tar.gz" && \
+    echo "URL: $url" && \
+    wget -O - $url | tar -xz && \
+    mv kiwix-tools*/kiwix-* /usr/local/bin && \
+    rm -r kiwix-tools*
+
+# expose kiwix-serve default port
+EXPOSE 80
+
+CMD ["/bin/sh", "-c", "echo 'Welcome to kiwix-tools! The following binaries are available:' && ls /usr/local/bin/"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,32 @@
+Kiwix-tools Docker image
+===
+
+- Available on [docker.io](https://hub.docker.com/r/kiwix/kiwix-tools) and [ghcr.io](https://ghcr.io/kiwix/kiwix-tools).
+- multi-arch (`linux/amd64`, `linux/arm64`, `linux/arm/v7`)
+- based on official `kiwix-tools` binaries.
+
+## Usage
+
+``` sh
+$ docker run -it kiwix/kiwix-tools:3.1.2
+
+Welcome to kiwix-tools! The following binaries are available:
+kiwix-manage  kiwix-read    kiwix-search  kiwix-serve
+```
+
+`kiwix-tools` operates on zim files. You shall mount a volume to access the files.
+
+```sh
+docker run -v $(pwd):/data -it kiwix/kiwix-tools kiwix-read --suggest="Mali" /data/wikipedia_fr_test.zim
+```
+
+## Building and reusing
+
+- `kiwix/kiwix-tools` is multi-arch and is ideally built using `buildx`.
+- requires a `--build-arg VERSION=` with the kiwix-tools release.
+- can be built using `docker build` in which case it expects an additionnal `--build-arg ARCH=arm` for arm. Otherwise defaults to `amd64`.
+
+**Notes:**
+
+- `wget` in `alpine:3` on `arm/v7` (__inside github action only__) crashes when downloading from HTTPs locations. Keep http-only in Dockerfile.
+- Was also unhappy when using the mirrors so it's using `mirror.download` on purpose.

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,21 +1,10 @@
-# declare build option ARCH
-ARG ARCH=
-# download ARCH-specific base image if specified
-FROM ${ARCH}alpine:3
-# decide which kiwix arch to download later (`armhf` for all arm* and x86_64 otherwise)
-ARG ARCH
-RUN if [ $(echo $ARCH | cut -c 1-3) = "arm" ] ; then echo "armhf" > /etc/kiwix_arch ; else echo "x86_64" > /etc/kiwix_arch ; fi
-LABEL maintainer Emmanuel Engelhart <kelson@kiwix.org>
+ARG VERSION=latest
 
-# Install kiwix-serve
-ARG RELEASE_ARCH="x86_64"
-WORKDIR /
-RUN apk add --no-cache curl bzip2
-RUN curl -kL https://download.kiwix.org/release/kiwix-tools/kiwix-tools_linux-$(cat /etc/kiwix_arch).tar.gz | tar -xz && \
-    mv kiwix-tools*/kiwix-serve /usr/local/bin && \
-    rm -r kiwix-tools*
+# kiwix-tools is multi-arch
+FROM kiwix/kiwix-tools:$VERSION
+LABEL org.opencontainers.image.source https://github.com/openzim/kiwix-tools
 
-# Run kiwix-serve
+# expose kiwix-serve default port and workdir
 EXPOSE 80
 VOLUME /data
 WORKDIR /data


### PR DESCRIPTION
- added a new generic kiwix/kiwix-tools image
- kiwix/kiwix-serve now based on kiwix/kiwix-tools ; with its entrypoint
- both images are built with official binary distribution
- both images are built on github action and pushed to both docker.io and ghcr.io
- both images are multi-arch and support arm/v7, arm64 and amd64
- built on release published or workflow_dispatch event (to be triggered by kiwix-build)

Fixes #373 and #410