### PR TITLE
This fixes the redundant error message when the kiwix server fails to start

### DIFF
--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -258,10 +258,6 @@ int main(int argc, char** argv)
   server.setBlockExternalLinks(blockExternalLinks);
 
   if (! server.start()) {
-    cerr << "Unable to instantiate the HTTP daemon. The port " << serverPort
-         << " is maybe already occupied or need more permissions to be open. "
-            "Please try as root or with a port number higher or equal to 1024."
-         << endl;
     exit(1);
   }
 


### PR DESCRIPTION
Fixes #483 