### PR TITLE
Fixed docker image for non-amd64 platforms

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,14 @@
+# dumb-init to use as entrypoint so it can forward signals to our CMD
+FROM debian:bullseye-slim as builder
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+    build-essential musl-tools wget unzip make \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+# compile dumb-init
+RUN wget -nv https://github.com/Yelp/dumb-init/archive/refs/tags/v1.2.5.zip && \
+    unzip v1.2.5.zip && cd dumb-init-1.2.5 && CC=musl-gcc make
+
 # declare build option ARCH if not using buildx
 ARG ARCH=
 # declare version to build image for
@@ -12,19 +23,17 @@ ARG TARGETARCH
 ARG VERSION
 ARG ARCH
 
-# defaulting to amd64
-RUN echo "amd64" > /etc/docker_arch
-# use --build-arg ARCH if it was provided (not using buildx)
-RUN if [ ! -z "$ARCH" ] ; then echo "$ARCH" > /etc/docker_arch ; fi
-# use $TARGETARCH if provided.
-RUN if [ ! -z "$TARGETARCH" ] ; then echo "$TARGETARCH" > /etc/docker_arch ; fi
+# copy built dumb-init
+COPY --from=builder /dumb-init-1.2.5/dumb-init /usr/bin/dumb-init
+
+# find and store arch in image, using (in this order):
+# $TARGETARCH || --build-arg ARCH (not using buildx) || amd64
+RUN echo "amd64" > /etc/docker_arch && \
+    if [ ! -z "$ARCH" ] ; then echo "$ARCH" > /etc/docker_arch ; fi && \
+    if [ ! -z "$TARGETARCH" ] ; then echo "$TARGETARCH" > /etc/docker_arch ; fi
 
 # decide which kiwix arch to download later (`armhf` for all arm* and x86_64 otherwise)
 RUN if [ $(cut -c 1-3 /etc/docker_arch) = "arm" ] ; then echo "armhf" > /etc/kiwix_arch ; else echo "x86_64" > /etc/kiwix_arch ; fi
-
-# dumb-init to use as entrypoint so it can forward signals to our CMD
-RUN wget -q -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 && \
-    chmod +x /usr/bin/dumb-init
 
 # Install kiwix-tools
 RUN url="http://mirror.download.kiwix.org/release/kiwix-tools/kiwix-tools_linux-$(cat /etc/kiwix_arch)-$VERSION.tar.gz" && \


### PR DESCRIPTION
PR#489 (01430603b689bdb213acd7cf6eaa712173dea59f) introduced dumb-init for better signals handling.
While this has the intended effect, it was done ny downloading the dumb-init static bin into the image… only using the amd64 version.

Ever since, the image(s) have been broken for armv7 and arm64.

As dumb-init doesn't provide 32b arm binary and because it's such a simple/small code, this fix compiles it in a builder shallow image ; ensuring we're getting an appropriate binary for the target arch.

We are also statically linking against musl-C as this is supported by dumb-init and is much smaller than glibc.