### PR TITLE
PPA: Fix libzim-dev and libkiwix-dev dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,8 +3,8 @@ Section: utils
 Priority: optional
 Maintainer: Kiwix team <kiwix@kiwix.org>
 Build-Depends: debhelper-compat (= 13),
-               libkiwix-dev (>= 10.0.0),
-               libzim-dev (>= 7.2.0),
+               libkiwix-dev (>= 10.0.0~),
+               libzim-dev (>= 7.2.0~),
                meson,
                pkg-config,
 Standards-Version: 4.5.0


### PR DESCRIPTION
```
Our libzim packages are "7.2.0~focal" but the ~ means that "7.2.0" is greater than
"7.2.0~focal" so the dependency can't be satisfied. Depending on "7.2.0~" will
allow "7.2.0~focal" to satisfy the dependency. Same for libkiwix.
```