### PR TITLE
Do not define stat if not necessary.

### DIFF
--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -138,7 +138,7 @@ void setup_sighandlers()
 
 uint64_t fileModificationTime(const std::string& path)
 {
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(stat)
 #define stat _stat
 #endif
   struct stat fileStatData;
@@ -375,11 +375,11 @@ int main(int argc, char** argv)
   if (! server.start()) {
     exit(1);
   }
-  
+
   std::string url = "http://" + server.getAddress() + ":" + std::to_string(server.getPort()) + "/" + rootLocation;
   std::cout << "The Kiwix server is running and can be accessed in the local network at: "
             << url << std::endl;
-            
+
   /* Run endless (until PPID dies) */
   waiting = true;
   do {


### PR DESCRIPTION
On recent mingw compiler, `stat` is already defined the same way we do.
So we don't need to do it.