### PR TITLE
Default kiwix-serve's rootLocation to "/"

### DIFF
--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -186,7 +186,7 @@ int main(int argc, char** argv)
   setup_sighandlers();
 #endif
 
-  std::string rootLocation = "";
+  std::string rootLocation = "/";
   kiwix::Library library;
   unsigned int nb_threads = DEFAULT_THREADS;
   std::vector<std::string> zimPathes;
@@ -393,7 +393,7 @@ int main(int argc, char** argv)
     exit(1);
   }
 
-  std::string url = "http://" + server.getAddress() + ":" + std::to_string(server.getPort()) + "/" + rootLocation;
+  std::string url = "http://" + server.getAddress() + ":" + std::to_string(server.getPort()) + rootLocation;
   std::cout << "The Kiwix server is running and can be accessed in the local network at: "
             << url << std::endl;
 

--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -103,6 +103,16 @@ std::string loadCustomTemplate (std::string customIndexPath) {
   return indexTemplateString;
 }
 
+inline std::string normalizeRootUrl(std::string rootUrl)
+{
+  while ( !rootUrl.empty() && rootUrl.back() == '/' )
+    rootUrl.pop_back();
+
+  while ( !rootUrl.empty() && rootUrl.front() == '/' )
+    rootUrl = rootUrl.substr(1);
+  return rootUrl.empty() ? rootUrl : "/" + rootUrl;
+}
+
 volatile sig_atomic_t waiting = false;
 volatile sig_atomic_t libraryMustBeReloaded = false;
 
@@ -393,7 +403,7 @@ int main(int argc, char** argv)
     exit(1);
   }
 
-  std::string url = "http://" + server.getAddress() + ":" + std::to_string(server.getPort()) + rootLocation;
+  std::string url = "http://" + server.getAddress() + ":" + std::to_string(server.getPort()) + normalizeRootUrl(rootLocation);
   std::cout << "The Kiwix server is running and can be accessed in the local network at: "
             << url << std::endl;
 


### PR DESCRIPTION
Usage mentions that the `rootLocation` defaults to `/` while it was not. It defaulted to an empty string.

While it defaulting to `""` or `"/"` has no technical consequence: libkiwix's server normalizes the requested rootLocation ; it leads to users setting a `"/"`-prefixed rootLocation when customizing it, resulting in double-slashed print of the URL
to access kiwix-serve at.

This harmonizes usage and actual default, fixing the URL print.