### PR TITLE
Make kiwix-serve easily deployable on podman Openshift

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -5,7 +5,7 @@ FROM kiwix/kiwix-tools:$VERSION
 LABEL org.opencontainers.image.source https://github.com/openzim/kiwix-tools
 
 # expose kiwix-serve default port and workdir
-EXPOSE 80
+EXPOSE 8080
 VOLUME /data
 WORKDIR /data
 

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -9,14 +9,23 @@ With local ZIM file(s)
 * Given `wikipedia.zim` and `wiktionary.zim` reside in `/tmp/zim/`, execute the following:
 
 ```bash
-docker run -v /tmp/zim:/data -p 8080:80 kiwix/kiwix-serve wikipedia.zim wiktionary.zim
+docker run -v /tmp/zim:/data -p 8080:8080 kiwix/kiwix-serve wikipedia.zim wiktionary.zim
 ```
 
 With remote ZIM file
 --------------------
 
 ```bash
-docker run -e "DOWNLOAD=https://download.kiwix.org/zim/wikipedia_bm_all.zim" -p 8080:80 kiwix/kiwix-serve
+docker run -e "DOWNLOAD=https://download.kiwix.org/zim/wikipedia_bm_all.zim" -p 8080:8080 kiwix/kiwix-serve
+```
+
+Change default port
+-------------------
+
+You can change port to expose with environment PORT, useful if running on Podman, K8s or OpenShift
+
+```bash
+podman run -e "DOWNLOAD=https://download.kiwix.org/zim/wikipedia_bm_all.zim" -e PORT=8888 -p 8080:8888 kiwix/kiwix-serve
 ```
 
 ARM

--- a/docker/server/docker-compose.yml.example
+++ b/docker/server/docker-compose.yml.example
@@ -2,7 +2,7 @@ version: '3.3'
 services:
   kiwix-serve:
       ports:
-        - 8080:80
+        - 8080:8080
       image: kiwix/kiwix-serve
       # uncomment next 4 lines to use it with local zim file in /tmp/zim
       # volumes:

--- a/docker/server/start.sh
+++ b/docker/server/start.sh
@@ -13,7 +13,11 @@ then
     fi
 fi
 
-CMD="/usr/local/bin/kiwix-serve --port=80 $@"
+if [ -z "$PORT" ]
+then
+    PORT=8080
+fi
+CMD="/usr/local/bin/kiwix-serve --port=$PORT $@"
 echo $CMD
 $CMD
 


### PR DESCRIPTION
With default port set to 80, it is not posible to run in user-mode, so added PORT enviroment and defaulted to 8080.

This make kiwix-serve container to be easily deployed on podman or even on OpenShift environment.