### PR TITLE
Docker compose example: Surround wildcard statement in quotes

### DIFF
--- a/docker/server/docker-compose.yml.example
+++ b/docker/server/docker-compose.yml.example
@@ -8,7 +8,7 @@ services:
       # volumes:
       #   - /tmp/zim:/data
       # command:
-      #   - *.zim
+      #   - '*.zim'
       # uncomment next 2 lines to use it with remote zim file
       # environment:
       #   - 'DOWNLOAD=https://download.kiwix.org/zim/wikipedia_bm_all.zim'


### PR DESCRIPTION
My docker compose did not like the wildcard at the beginning. I had to surround it with quotes before it would run.