### PR TITLE
Update GitHub workflow actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
     name: Deploy kiwix-tools Docker Image
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
       - name: build and publish kiwix-tools
         uses: openzim/docker-publish-action@v9
         with:
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: build-and-push-kiwix-tools
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
       - name: build and publish kiwix-serve
         uses: openzim/docker-publish-action@v9
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,7 +12,7 @@ jobs:
           - ubuntu-impish
           - ubuntu-focal
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Determine which PPA we should upload to
       - name: PPA
@@ -57,7 +57,7 @@ jobs:
           args: --no-sign
           ppa: ${{ steps.ppa.outputs.ppa }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Packages for ${{ matrix.distro }}
           path: output


### PR DESCRIPTION
Do avoid CI warnings because these old actions rely on deprecated Node.js 12