### PR TITLE
kiwix-serve: Skip broken ZIM files and continue startup

### DIFF
--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -77,6 +77,7 @@ void usage()
             << "\t-z, --nodatealiases\tCreate URL aliases for each content by removing the date" << std::endl
             << "\t-c, --customIndex\tAdd path to custom index.html for welcome page" << std::endl
             << "\t-L, --ipConnectionLimit\tMax number of (concurrent) connections per IP (default: infinite, recommended: >= 6)" << std::endl
+            << "\t-k, --skipBroken\tStartup the server even when ZIM files are broken (those will be skipped)" << std::endl
             << std::endl
 
             << "Documentation:" << std::endl
@@ -217,6 +218,7 @@ int main(int argc, char** argv)
   unsigned int PPID = 0;
   int ipConnectionLimit = 0;
   int searchLimit = 0;
+  bool skipBroken = false;
 
   static struct option long_options[]
       = {{"daemon", no_argument, 0, 'd'},
@@ -237,6 +239,7 @@ int main(int argc, char** argv)
          {"monitorLibrary", no_argument, 0, 'M'},
          {"ipConnectionLimit", required_argument, 0, 'L'},
          {"searchLimit", required_argument, 0, 's'},
+         {"skipBroken", no_argument, 0, 'k'},
          {0, 0, 0, 0}};
 
   std::set<int> usedOptions;
@@ -307,6 +310,9 @@ int main(int argc, char** argv)
         case 's':
           searchLimit = atoi(optarg);
           break;
+        case 'k':
+          skipBroken = true;
+          break;
         case '?':
           usage();
           return 2;
@@ -348,9 +354,13 @@ int main(int argc, char** argv)
     std::vector<std::string>::iterator it;
     for (it = zimPathes.begin(); it != zimPathes.end(); it++) {
       if (!manager.addBookFromPath(*it, *it, "", false)) {
-        std::cerr << "Unable to add the ZIM file '" << *it
-             << "' to the internal library." << std::endl;
-        exit(1);
+        if ( skipBroken ) {
+          std::cerr << "Skipping broken '" << *it << "' ...continuing" << std::endl;
+        } else {
+          std::cerr << "Unable to add the ZIM file '" << *it
+               << "' to the internal library." << std::endl;
+          exit(1);
+        }
       }
     }
   }


### PR DESCRIPTION
I have this problem sometimes when a ZIM is currently downloading but I still want to start the server...

Fixes #658