### PR TITLE
Reinstated the RTD Sphinx Theme for documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+        "sphinx_rtd_theme"
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -41,8 +42,7 @@ templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 
-if not on_rtd:
-    html_theme = 'sphinx_rtd_theme'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Back when the `kiwix-serve` documentation was introduced (in the end of 2022) the [theme choice question was raised and a deliberate selection in favour of the RTD Sphinx theme was made](https://github.com/kiwix/kiwix-tools/pull/586#issuecomment-1365831225).

Then sometime in 2023 the [default theme on Read-the-Docs was changed to Alabaster](https://github.com/readthedocs/readthedocs.org/issues/10692).

This change enforces the old theme (sphinx_rtd_theme).