### PR TITLE
Run the CI on pull_request.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   Linux:


### PR DESCRIPTION
Running the CI on push only trigger the CI on a push on the current repository. It works on PR based on local branch but not for PR from remote repository.