### PR TITLE
kiwix-serve displays both protocol attached ips

### DIFF
--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -60,22 +60,22 @@ Mandatory arguments:
 
 Options:
  -h --help                               Print this help
- -a=<pid> --attachToProcess=<pid>        Exit if given process id is not running anymore [default: 0]
+ -a <pid> --attachToProcess=<pid>        Exit if given process id is not running anymore [default: 0]
  -d --daemon                             Detach the HTTP server daemon from the main process
- -i=<address> --address=<address>        Listen only on the specified IP address. Specify 'ipv4', 'ipv6' or 'all' to listen on all IPv4, IPv6 or both types of addresses, respectively [default: all]
+ -i <address> --address=<address>        Listen only on the specified IP address. Specify 'ipv4', 'ipv6' or 'all' to listen on all IPv4, IPv6 or both types of addresses, respectively [default: all]
  -M --monitorLibrary                     Monitor the XML library file and reload it automatically
  -m --nolibrarybutton                    Don't print the builtin home button in the builtin top bar overlay
  -n --nosearchbar                        Don't print the builtin bar overlay on the top of each served page
  -b --blockexternal                      Prevent users from directly accessing external links
- -p=<port> --port=<port>                 Port on which to listen to HTTP requests [default: 80]
- -r=<root> --urlRootLocation=<root>      URL prefix on which the content should be made available [default: /]
- -s=<limit> --searchLimit=<limit>        Maximun number of zim in a fulltext multizim search [default: 0]
- -t=<threads> --threads=<threads>        Number of threads to run in parallel [default: )" AS_STR(DEFAULT_THREADS) R"(]
+ -p <port> --port=<port>                 Port on which to listen to HTTP requests [default: 80]
+ -r <root> --urlRootLocation=<root>      URL prefix on which the content should be made available [default: /]
+ -s <limit> --searchLimit=<limit>        Maximun number of zim in a fulltext multizim search [default: 0]
+ -t <threads> --threads=<threads>        Number of threads to run in parallel [default: )" AS_STR(DEFAULT_THREADS) R"(]
  -v --verbose                            Print debug log to STDOUT
  -V --version                            Print software version
  -z --nodatealiases                      Create URL aliases for each content by removing the date
- -c=<path> --customIndex=<path>          Add path to custom index.html for welcome page
- -L=<limit> --ipConnectionLimit=<limit>  Max number of (concurrent) connections per IP [default: 0] (recommended: >= 6)
+ -c <path> --customIndex=<path>          Add path to custom index.html for welcome page
+ -L <limit> --ipConnectionLimit=<limit>  Max number of (concurrent) connections per IP [default: 0] (recommended: >= 6)
  -k --skipInvalid                        Startup even when ZIM files are invalid (those will be skipped)
 
 Documentation:

--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -326,14 +326,14 @@ int main(int argc, char** argv)
 
   kiwix::IpMode ipMode = kiwix::IpMode::AUTO;
 
-  if (address == "all"){
-    address = "";
+  if (address == "all") {
+    address.clear();
     ipMode = kiwix::IpMode::ALL;
-  } else if (address == "ipv4"){
-    address = "";
+  } else if (address == "ipv4") {
+    address.clear();
     ipMode = kiwix::IpMode::IPV4;
-  } else if (address == "ipv6"){
-    address = "";
+  } else if (address == "ipv6") {
+    address.clear();
     ipMode = kiwix::IpMode::IPV6;
   }
 

--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -324,17 +324,17 @@ int main(int argc, char** argv)
   auto libraryFileTimestamp = newestFileTimestamp(libraryPaths);
   auto curLibraryFileTimestamp = libraryFileTimestamp;
 
-  /* Infer ipMode from address */
-  kiwix::IpMode ipMode = kiwix::IpMode::ipv4;
+  kiwix::IpMode ipMode = kiwix::IpMode::AUTO;
 
   if (address == "all"){
     address = "";
-    ipMode = kiwix::IpMode::all;
+    ipMode = kiwix::IpMode::ALL;
   } else if (address == "ipv4"){
     address = "";
+    ipMode = kiwix::IpMode::IPV4;
   } else if (address == "ipv6"){
     address = "";
-    ipMode = kiwix::IpMode::ipv6;
+    ipMode = kiwix::IpMode::IPV6;
   }
 
 #ifndef _WIN32
@@ -384,12 +384,12 @@ int main(int argc, char** argv)
     exit(1);
   }
 
-  std::string host = (server.getIpMode()==kiwix::IpMode::all || server.getIpMode()==kiwix::IpMode::ipv6)
-                     ? "[" + server.getAddress() + "]" : server.getAddress();
-
-  std::string url = "http://" + host + ":" + std::to_string(server.getPort()) + normalizeRootUrl(rootLocation);
-  std::cout << "The Kiwix server is running and can be accessed in the local network at: "
-            << url << std::endl;
+  std::string prefix = "http://";
+  kiwix::IpAddress addresses = server.getAddress();
+  std::string suffix = ":" + std::to_string(server.getPort()) + normalizeRootUrl(rootLocation);
+  std::cout << "The Kiwix server is running and can be accessed in the local network at: " << std::endl;
+  if(!addresses.addr.empty()) std::cout << "  - " << prefix << addresses.addr << suffix << std::endl;
+  if(!addresses.addr6.empty()) std::cout << "  - " << prefix << "[" << addresses.addr6 << "]" <<  suffix << std::endl;
 
   /* Run endless (until PPID dies) */
   waiting = true;


### PR DESCRIPTION
This changes the logic to use the refactored `getBestPublicIps` so kiwix-serve can display all attached ips based on the protocol that was requested by the user.

Fixes #703

Relies on https://github.com/kiwix/libkiwix/pull/1132