### PR TITLE
[Docker] kiwix-serve image to use unprivileged user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.18
-LABEL org.opencontainers.image.source https://github.com/openzim/kiwix-tools
+LABEL org.opencontainers.image.source=https://github.com/openzim/kiwix-tools
 
 # TARGETPLATFORM is injected by docker build
 ARG TARGETPLATFORM

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -9,13 +9,11 @@ EXPOSE 8080
 VOLUME /data
 WORKDIR /data
 
-COPY ./start.sh /usr/local/bin/
-
 # Create non-root user for better security
 RUN addgroup -S user && adduser -S user -G user
-# Change ownership of the start script to the new user
-RUN chown user:user /usr/local/bin/start.sh
 # Switch to the non-root user
 USER user
+
+COPY ./start.sh /usr/local/bin/
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/local/bin/start.sh"]

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -9,9 +9,8 @@ EXPOSE 8080
 VOLUME /data
 WORKDIR /data
 
-# Create non-root user for better security
+# running as a named unprivileged user
 RUN addgroup -S user && adduser -S user -G user
-# Switch to the non-root user
 USER user
 
 COPY ./start.sh /usr/local/bin/

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -2,7 +2,7 @@ ARG VERSION=latest
 
 # kiwix-tools is multi-arch
 FROM ghcr.io/kiwix/kiwix-tools:$VERSION
-LABEL org.opencontainers.image.source https://github.com/openzim/kiwix-tools
+LABEL org.opencontainers.image.source=https://github.com/openzim/kiwix-tools
 
 # expose kiwix-serve default port and workdir
 EXPOSE 8080
@@ -10,5 +10,12 @@ VOLUME /data
 WORKDIR /data
 
 COPY ./start.sh /usr/local/bin/
+
+# Create non-root user for better security
+RUN addgroup -S kiwix && adduser -S kiwix -G kiwix
+# Change ownership of the start script to the new user
+RUN chown kiwix:kiwix /usr/local/bin/start.sh
+# Switch to the non-root user
+USER kiwix
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/local/bin/start.sh"]

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -12,10 +12,10 @@ WORKDIR /data
 COPY ./start.sh /usr/local/bin/
 
 # Create non-root user for better security
-RUN addgroup -S kiwix && adduser -S kiwix -G kiwix
+RUN addgroup -S user && adduser -S user -G user
 # Change ownership of the start script to the new user
-RUN chown kiwix:kiwix /usr/local/bin/start.sh
+RUN chown user:user /usr/local/bin/start.sh
 # Switch to the non-root user
-USER kiwix
+USER user
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/local/bin/start.sh"]


### PR DESCRIPTION
### Enhanced Kiwix-Serve Dockerfile

- **Added unpriviliged user for executing kiwix-serve**
This minimizes the code that runs on elevated privileges and allows to execute the Docker-container in rootless mode, enhancing overall security.

- **Switched to new key-value-format**
Following Docker recommendations, all LABEL key-value pairs should be of the structure "key=value" and not "key value".