### PR TITLE
alpine-version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.22
 LABEL org.opencontainers.image.source=https://github.com/openzim/kiwix-tools
 
 # TARGETPLATFORM is injected by docker build


### PR DESCRIPTION
fixes: #769 

I updated the base image to Alpine 3.20 because it’s the latest stable and supported release, ensuring security patches and compatibility.
Using the rolling `3` or `latest` tags was avoided to maintain build reproducibility and stability.