### PR TITLE
Fix kiwix-manage docopt integration

### DIFF
--- a/src/manager/kiwix-manage.cpp
+++ b/src/manager/kiwix-manage.cpp
@@ -93,17 +93,18 @@ Documentation:
 int handle_show(const kiwix::Library& library, const std::string& libraryPath,
                  const Options& options)
 {
-  if (options.at("ZIMID").isStringList()) {
-    auto bookIds = options.at("ZIMID").asStringList();
-    for(auto& bookId: bookIds) {
-       show(library, bookId);
-    }
-  } else {
+  if (options.at("ZIMID").asStringList().empty()) {
     auto booksIds = library.getBooksIds();
     for(auto& bookId: booksIds) {
       show(library, bookId);
     }
+  } else {
+    auto bookIds = options.at("ZIMID").asStringList();
+    for(auto& bookId: bookIds) {
+       show(library, bookId);
+    }
   }
+
   return(0);
 }
 


### PR DESCRIPTION
Fixes #780
Fixes #781

Many regressions have been introduced by moving from `getopt()` to `docopt++` at 504a7a1. This fixes bad handling for kiwix-manage commands `add`, `remove` and `show`.