### PR TITLE
Allow ingesting a library directly from an OPDS feed (closes #1309)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .idea/
 buildDir/
-BUILD_native_dyn/
-BUILD_neutral/
+build/
+BUILD_*/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/
+buildDir/
+BUILD_native_dyn/
+BUILD_neutral/

--- a/src/manager/kiwix-manage.cpp
+++ b/src/manager/kiwix-manage.cpp
@@ -197,7 +197,12 @@ int main(int argc, char** argv)
                     ? kiwix::computeAbsolutePath(kiwix::getCurrentDirectory(), libraryPath)
                     : libraryPath;
   kiwix::Manager manager(library);
-  if (!manager.readFile(libraryPath, false)) {
+
+  auto format = (kiwix::getFileContent(libraryPath).find("<feed") != std::string::npos)
+              ? kiwix::Manager::FileFormat::OPDS
+              : kiwix::Manager::FileFormat::XML;
+
+  if (!manager.readFile(format, libraryPath, "", false)) {
     if (kiwix::fileExists(libraryPath) || action!=ADD) {
       std::cerr << "Cannot read the library " << libraryPath << std::endl;
       return 1;
@@ -226,8 +231,11 @@ int main(int argc, char** argv)
 
   /* Rewrite the library file */
   if (action == REMOVE || action == ADD) {
-    // writeToFile return true (1) if everything is ok => exitCode is 0
-    if (!library->writeToFile(libraryPath)) {
+    // writeToXMLFile/writeToOPDSFile return true (1) if everything is ok => exitCode is 0
+    bool writeOk = format == kiwix::Manager::FileFormat::OPDS
+                 ? library->writeToOPDSFile(libraryPath)
+                 : library->writeToXMLFile(libraryPath);
+    if (!writeOk) {
       std::cerr << "Cannot write the library " << libraryPath << std::endl;
       return 1;
     }

--- a/src/manager/kiwix-manage.cpp
+++ b/src/manager/kiwix-manage.cpp
@@ -44,6 +44,7 @@ void show(const kiwix::Library& library, const std::string& bookId)
               << "date:\t\t" << book.getDate() << std::endl
               << "articleCount:\t" << book.getArticleCount() << std::endl
               << "mediaCount:\t" << book.getMediaCount() << std::endl
+              << "illustrationsCount:\t" << book.getIllustrations().size() << std::endl
               << "size:\t\t" << book.getSize() << " KB" << std::endl;
   } catch (std::out_of_range&) {
      std::cout << "No book " << bookId << " in the library" << std::endl;

--- a/src/manager/kiwix-manage.cpp
+++ b/src/manager/kiwix-manage.cpp
@@ -198,7 +198,6 @@ int main(int argc, char** argv)
                     ? kiwix::computeAbsolutePath(kiwix::getCurrentDirectory(), libraryPath)
                     : libraryPath;
   kiwix::Manager manager(library);
-
   if (!manager.readFile(libraryPath, "", false)) {
     if (kiwix::fileExists(libraryPath) || action!=ADD) {
       std::cerr << "Cannot read the library " << libraryPath << std::endl;

--- a/src/manager/kiwix-manage.cpp
+++ b/src/manager/kiwix-manage.cpp
@@ -198,11 +198,7 @@ int main(int argc, char** argv)
                     : libraryPath;
   kiwix::Manager manager(library);
 
-  auto format = (kiwix::getFileContent(libraryPath).find("<feed") != std::string::npos)
-              ? kiwix::Manager::FileFormat::OPDS
-              : kiwix::Manager::FileFormat::XML;
-
-  if (!manager.readFile(format, libraryPath, "", false)) {
+  if (!manager.readFile(libraryPath, "", false)) {
     if (kiwix::fileExists(libraryPath) || action!=ADD) {
       std::cerr << "Cannot read the library " << libraryPath << std::endl;
       return 1;
@@ -232,7 +228,7 @@ int main(int argc, char** argv)
   /* Rewrite the library file */
   if (action == REMOVE || action == ADD) {
     // writeToXMLFile/writeToOPDSFile return true (1) if everything is ok => exitCode is 0
-    bool writeOk = format == kiwix::Manager::FileFormat::OPDS
+    bool writeOk = manager.detectFormat(libraryPath) == kiwix::Manager::FileFormat::OPDS
                  ? library->writeToOPDSFile(libraryPath)
                  : library->writeToXMLFile(libraryPath);
     if (!writeOk) {

--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -294,7 +294,7 @@ int main(int argc, char** argv)
   std::vector<std::string> libraryPaths;
   if (!libraryPath.empty()) {
     libraryPaths = kiwix::split(libraryPath, ";");
-    if ( !reloadLibrary(manager, libraryPaths) ) {
+    if (!reloadLibrary(manager, libraryPaths)) {
       exit(1);
     }
 
@@ -428,7 +428,7 @@ int main(int argc, char** argv)
       }
     }
 
-    if ( libraryMustBeReloaded && !libraryPaths.empty() ) {
+    if (libraryMustBeReloaded && !libraryPaths.empty()) {
       libraryFileTimestamp = curLibraryFileTimestamp;
       reloadLibrary(manager, libraryPaths);
       nameMapper->update();


### PR DESCRIPTION
- Fix: ZIM files served via an OPDS library file (kiwix-serve --library some.opds) were silently excluded from search, the home page, and /catalog/v2/entries, even  
  when the referenced ZIM path was valid and the file existed on disk.                                                                                                 
  - Root cause: Book::updateFromOpds() never set m_pathValid, so it stayed at its constructor default of false for every book loaded from an OPDS feed — unlike        
  Book::updateFromXml(), which sets m_pathValid = fileReadable(path).                                                                                                  
  - Downstream effect: kiwix-serve's Filter().valid(true) (used by the home page, /search, and /catalog/v2/entries) filtered out all OPDS-sourced books, so nothing    
  appeared in the browser despite the library loading "successfully" with no error.                                                                                    
  - Fix: set m_pathValid = fileReadable(m_path) when parsing the rel="self" link in updateFromOpds(), mirroring the XML path.