### PR TITLE
Fix size unit display in kiwix-manage show

### DIFF
--- a/src/manager/kiwix-manage.cpp
+++ b/src/manager/kiwix-manage.cpp
@@ -44,7 +44,7 @@ void show(const kiwix::Library& library, const std::string& bookId)
               << "date:\t\t" << book.getDate() << std::endl
               << "articleCount:\t" << book.getArticleCount() << std::endl
               << "mediaCount:\t" << book.getMediaCount() << std::endl
-              << "size:\t\t" << book.getSize() << " KB" << std::endl;
+              << "size:\t\t" << (book.getSize() / 1024) << " KiB" << std::endl;
   } catch (std::out_of_range&) {
      std::cout << "No book " << bookId << " in the library" << std::endl;
   }


### PR DESCRIPTION
## Description
`kiwix-manage show` reports the ZIM file size with an incorrect unit.
`book.getSize()` returns the size in bytes, but the output labels it
as "KB", making a ~100 MB file appear as ~100 GB.

## Fix
Convert the byte value to KB by right-shifting by 10 (dividing by 1024)
before displaying.

## Before
size: 104832000 KB (implies ~100 GB — incorrect)

## After
size: 102375 KB (~100 MB — correct)

Fixes #827