### PR TITLE
feat: use kiwix::beautifyFileSize for printing book size in kiwix-manage

### DIFF
--- a/src/manager/kiwix-manage.cpp
+++ b/src/manager/kiwix-manage.cpp
@@ -44,7 +44,7 @@ void show(const kiwix::Library& library, const std::string& bookId)
               << "date:\t\t" << book.getDate() << std::endl
               << "articleCount:\t" << book.getArticleCount() << std::endl
               << "mediaCount:\t" << book.getMediaCount() << std::endl
-              << "size:\t\t" << (book.getSize() / 1024) << " KiB" << std::endl;
+              << "size:\t\t" << kiwix::beautifyFileSize(book.getSize()) << std::endl;
   } catch (std::out_of_range&) {
      std::cout << "No book " << bookId << " in the library" << std::endl;
   }


### PR DESCRIPTION
PR raised to solve issue #830
Depends on Merged PR #1328 at kiwix/libkiwix

Replaces the manual `/ 1024` calculation and hardcoded `"KiB"` suffix in `kiwix-manage` with `kiwix::beautifyFileSize()` present under `kiwix/libkiwix`.

Calls `kiwix::beautifyFileSize(book.getSize())` in `show()` inside `src/manager/kiwix-manage.cpp`.
Outputs human-readable file sizes (e.g. `569.34 KB`, `20.74 GB`) using SI (base-1000) decimal units.