### PR TITLE
fix(searcher): fallback to system temp directory when HOME is unset

### DIFF
--- a/src/searcher/kiwix-search.cpp
+++ b/src/searcher/kiwix-search.cpp
@@ -58,8 +58,13 @@ Options:
 
 std::filesystem::path getKiwixCachedDataDirPath()
 {
-  std::filesystem::path home(getenv("HOME"));
-  std::filesystem::path cacheDirPath = home / ".cache" / "kiwix";
+  std::filesystem::path cacheDirPath;
+  const char* homeEnv = getenv("HOME");
+  if (homeEnv) {
+    cacheDirPath = std::filesystem::path(homeEnv) / ".cache" / "kiwix";
+  } else {
+    cacheDirPath = std::filesystem::temp_directory_path() / "kiwix-cache";
+  }
   std::filesystem::create_directories(cacheDirPath);
   return cacheDirPath;
 }


### PR DESCRIPTION
PR raised to solve issue #832 

Fixes a Segmentation Fault in `kiwix-search` when the `HOME` environment variable is not defined (e.g., in containerized, Kubernetes, or minimal server environments).

`getKiwixCachedDataDirPath()` now checks if `getenv("HOME")` returns `nullptr`. 
  - If `$HOME` is set: uses `$HOME/.cache/kiwix`.
  - If `$HOME` is unset: falls back to `std::filesystem::temp_directory_path() / "kiwix-cache"` (resolving to `/tmp/kiwix-cache` on Unix/Linux).

Testing:
Again ran the same command `env -u HOME kiwix-search --spelling ...` and it now no longer crashes with a segmentation fault.

<img width="1099" height="94" alt="Screenshot From 2026-08-18 13-15-32" src="https://github.com/user-attachments/assets/0aeae6dc-3f45-45a5-8383-987e5d567487" />
