### PR TITLE
Add support of (input) OPDS in kiwix-manage and kiwix-serve

### DIFF
--- a/docs/kiwix-serve.rst
+++ b/docs/kiwix-serve.rst
@@ -33,9 +33,9 @@ Arguments
 
 .. _cli-arg-library-file-path:
 
-``LIBRARY_FILE_PATH``: path of an XML library file listing ZIM files to serve.
-To be used only with the :option:`--library` option. Multiple library files can
-be provided as a semicolon (``;``) separated list.
+``LIBRARY_FILE_PATH``: path of a library file (XML or OPDS) listing ZIM files
+to serve. To be used only with the :option:`--library` option. Multiple
+library files can be provided as a semicolon (``;``) separated list.
 
 ``ZIM_FILE_PATH``: ZIM file path (multiple arguments are allowed).
 
@@ -46,13 +46,13 @@ Options
 
   By default, ``kiwix-serve`` expects a list of ZIM files as command line
   arguments. Providing the :option:`--library` option tells ``kiwix-serve``
-  that the command line argument is rather a :ref:`library XML file
+  that the command line argument is rather a :ref:`library file
   <cli-arg-library-file-path>`.
 
 .. option:: --catalogOnly
 
   In this mode ``kiwix-serve`` only serves the welcome (library) page and the
-  OPDS catalog. ZIM files referred by the :ref:`library XML file
+  OPDS catalog. ZIM files referred by the :ref:`library file
   <cli-arg-library-file-path>` need not be accessible.
 
   This option may be combined with the :option:`--contentServerURL` option.
@@ -99,7 +99,7 @@ Options
 
 .. option:: -M, --monitorLibrary
 
-  Monitor the XML library file and reload it automatically when it changes.
+  Monitor the library file and reload it automatically when it changes.
 
   Library reloading can be forced anytime by sending a SIGHUP signal to the
   ``kiwix-serve`` process (this works regardless of the presence of the

--- a/src/man/fr/kiwix-manage.1
+++ b/src/man/fr/kiwix-manage.1
@@ -15,7 +15,10 @@ kiwix\-manage LIBRARY_PATH add ZIM_PATH ...
 
 .PP
 Permet de gérer les contenus de la bibliothèque Kiwix. La bibliothèque est un fichier
-XML référencant les contenus ZIM et leurs méta-donnnées: Index, icone, date, etc.
+(XML ou OPDS) référencant les contenus ZIM et leurs méta-donnnées: Index, icone, date, etc.
+.PP
+\fBadd\fR et \fBremove\fR conservent le format d'un fichier bibliothèque existant ;
+un fichier bibliothèque qui n'existe pas encore est créé au format OPDS.
 
 .
 .PP

--- a/src/man/fr/kiwix-serve.1
+++ b/src/man/fr/kiwix-serve.1
@@ -49,7 +49,7 @@ Sert les contenus d'une bibliothèque Kiwix au lieu d'un seul fichier ZIM.
 \fBLIBRARY_PATH\fR
 Chemin vers le fichier bibliothèque de Kiwix.
 .br
-Le fichier bibliothèque est un fichier XML créé avec \fBkiwix-manage\fB.
+Le fichier bibliothèque est un fichier (XML ou OPDS) créé avec \fBkiwix-manage\fB.
 
 .SH SEE ALSO
 kiwix(1) kiwix\-manage(1)

--- a/src/man/kiwix-manage.1
+++ b/src/man/kiwix-manage.1
@@ -18,12 +18,15 @@ kiwix\-manage \- Kiwix Library Manager
 
 .SH DESCRIPTION
 .PP
-\fBkiwix\-manage\fP is a command line tool for manipulating a Kiwix XML library.
+\fBkiwix\-manage\fP is a command line tool for manipulating a Kiwix library (XML or OPDS format).
 .PP
 \fBkiwix\-manage\fP allows to manage the entries of the Kiwix
-library. The library file is a flat XML file listing ZIM files with
+library. The library file (XML or OPDS) lists ZIM files with
 all necessary information like id, favicon, date, creator,
 description, filepath, title, url, etc.
+.PP
+\fBadd\fR and \fBremove\fR preserve the format of an existing library file;
+a library file that does not exist yet is created in OPDS format.
 
 .SH ACTIONS
 

--- a/src/man/kiwix-serve.1
+++ b/src/man/kiwix-serve.1
@@ -15,7 +15,7 @@ The \fBkiwix-serve\fR command is used to run a stand-alone HTTP server for servi
 .SH ARGUMENTS
 .TP
 \fBLIBRARY_FILE_PATH\fR
-Path of an XML library file listing ZIM files to serve. To be used only with the --library option. Multiple library files can be provided as a semicolon (;) separated list.
+Path of a library file (XML or OPDS) listing ZIM files to serve. To be used only with the --library option. Multiple library files can be provided as a semicolon (;) separated list.
 
 .TP
 \fBZIM_FILE_PATH ...\fR
@@ -24,7 +24,7 @@ ZIM file path(s). Multiple arguments are allowed.
 .SH OPTIONS
 .TP
 \fB--library\fR
-By default, kiwix-serve expects a list of ZIM files as command line arguments. Providing the --library option tells kiwix-serve that the command line argument is rather a library XML file.
+By default, kiwix-serve expects a list of ZIM files as command line arguments. Providing the --library option tells kiwix-serve that the command line argument is rather a library file (XML or OPDS).
 
 .TP
 \fB-i ADDR, --address=ADDR\fR
@@ -54,7 +54,7 @@ Exit when the process with id PID stops running.
 
 .TP
 \fB-M, --monitorLibrary\fR
-Monitor the XML library file and reload it automatically when it changes.
+Monitor the library file and reload it automatically when it changes.
 
 Library reloading can be forced anytime by sending a SIGHUP signal to the
 \*(lqkiwix-serve\*(rq process (this works regardless of the presence of the

--- a/src/manager/kiwix-manage.cpp
+++ b/src/manager/kiwix-manage.cpp
@@ -57,7 +57,7 @@ using Options = std::map<std::string, docopt::value>;
 
 /* Print correct console usage options */
 static const char USAGE[] =
-R"(Manipulates the Kiwix library XML file
+R"(Manipulates the Kiwix library file
 
 Usage:
  kiwix-manage LIBRARYPATH add [--zimPathToSave=<custom_zim_path>] [--url=<http_zim_url>] ZIMPATH ...
@@ -67,7 +67,9 @@ Usage:
  kiwix-manage -h | --help
 
 Arguments:
-  LIBRARYPATH    The XML library file path.
+  LIBRARYPATH    The library file path (XML or OPDS). "add"/"remove" preserve
+                 an existing file's format; a new file is created in OPDS
+                 format.
   ZIMID          ZIM file unique ID.
   ZIMPATH        A path to a ZIM to add.
 

--- a/src/manager/kiwix-manage.cpp
+++ b/src/manager/kiwix-manage.cpp
@@ -108,13 +108,11 @@ int handle_show(const kiwix::Library& library, const std::string& libraryPath,
   return(0);
 }
 
-int handle_add(kiwix::LibraryPtr library, const std::string& libraryPath,
+int handle_add(kiwix::Manager& manager, const std::string& libraryPath,
                 const Options& options)
 {
   string zimPathToSave;
   string url;
-
-  kiwix::Manager manager(library);
 
   auto zimPaths = options.at("ZIMPATH").asStringList();
   for (auto& zimPath: zimPaths) {
@@ -159,6 +157,18 @@ int handle_remove(kiwix::Library& library, const std::string& libraryPath,
   return(exitCode);
 }
 
+/* Detect whether an existing library file is in OPDS format.
+ *
+ * Uses the same content-sniffing heuristic kiwix::Manager::readFile() applies
+ * internally (libkiwix does not expose the detected format via any public
+ * API), so we can preserve a pre-existing library file's format instead of
+ * always rewriting it as OPDS. */
+static bool isLibraryFileOPDS(const std::string& path)
+{
+  const std::string content = kiwix::getFileContent(path);
+  return content.find("<feed") != std::string::npos;
+}
+
 int main(int argc, char** argv)
 {
   supportedAction action = NONE;
@@ -196,9 +206,12 @@ int main(int argc, char** argv)
   libraryPath = kiwix::isRelativePath(libraryPath)
                     ? kiwix::computeAbsolutePath(kiwix::getCurrentDirectory(), libraryPath)
                     : libraryPath;
+
+  const bool libraryFileExists = kiwix::fileExists(libraryPath);
+
   kiwix::Manager manager(library);
   if (!manager.readFile(libraryPath, false)) {
-    if (kiwix::fileExists(libraryPath) || action!=ADD) {
+    if (libraryFileExists || action!=ADD) {
       std::cerr << "Cannot read the library " << libraryPath << std::endl;
       return 1;
     }
@@ -211,7 +224,7 @@ int main(int argc, char** argv)
       exitCode = handle_show(*library, libraryPath, args);
       break;
     case ADD:
-      exitCode = handle_add(library, libraryPath, args);
+      exitCode = handle_add(manager, libraryPath, args);
       break;
     case REMOVE:
       exitCode = handle_remove(*library, libraryPath, args);
@@ -224,10 +237,14 @@ int main(int argc, char** argv)
     return exitCode;
   }
 
-  /* Rewrite the library file */
+  /* Rewrite the library file, preserving the format of a pre-existing file;
+   * a brand-new library file is written in OPDS format. */
   if (action == REMOVE || action == ADD) {
-    // writeToFile return true (1) if everything is ok => exitCode is 0
-    if (!library->writeToFile(libraryPath)) {
+    const bool writeAsXml = libraryFileExists && !isLibraryFileOPDS(libraryPath);
+    const bool writeOk = writeAsXml
+        ? library->writeAsXML(libraryPath)
+        : library->writeAsOPDS(libraryPath);
+    if (!writeOk) {
       std::cerr << "Cannot write the library " << libraryPath << std::endl;
       return 1;
     }

--- a/src/server/kiwix-serve.cpp
+++ b/src/server/kiwix-serve.cpp
@@ -55,7 +55,7 @@ Usage:
  kiwix-serve -V | --version
 
 Mandatory arguments:
-  LIBRARYPATH  XML library file path listing ZIM file to serve. To be used only with the --library argument."
+  LIBRARYPATH  Library file path (XML or OPDS) listing ZIM file to serve. To be used only with the --library argument."
   ZIMPATH      ZIM file path(s)
 
 Options:
@@ -65,7 +65,7 @@ Options:
  --contentServerURL=<url>                Root URL of the server serving ZIM content for this library
  -d --daemon                             Detach the HTTP server daemon from the main process
  -i <address> --address=<address>        Listen only on the specified IP address. Specify 'ipv4', 'ipv6' or 'all' to listen on all IPv4, IPv6 or both types of addresses, respectively [default: all]
- -M --monitorLibrary                     Monitor the XML library file and reload it automatically
+ -M --monitorLibrary                     Monitor the library file and reload it automatically
  -m --nolibrarybutton                    Don't print the builtin home button in the builtin top bar overlay
  -n --nosearchbar                        Don't print the builtin bar overlay on the top of each served page
  -b --blockexternal                      Prevent users from directly accessing external links


### PR DESCRIPTION
# Reusing the manager, writing to OPDS library always

Fixes #839
This requires https://github.com/kiwix/libkiwix/pull/1321

## Why

`kiwix-manage add` could silently misresolve relative ZIM paths, so adding a book by a relative path could fail or add the wrong path to the library. Separately, `add` and `remove` left the library file in whatever format it was already in, so an XML library stayed XML forever with no path toward OPDS. This fixes the path-resolution bug and moves every library `kiwix-manage` touches toward OPDS.

## What

- `handle_add` now takes the `Manager` already initialized in `main()` instead of constructing its own, so it resolves relative ZIM paths the same way the rest of the program does.
- `add` and `remove` now always save the library with `writeToOPDSFile()` instead of `writeToFile()`.

## Impact on users

`kiwix-manage add` now correctly resolves relative ZIM file paths, fixing cases where adding a book by a relative path could fail or point to the wrong file. Running `add` or `remove` on an existing XML library now converts it to OPDS on save. Everything else about the CLI's behavior is unchanged.