### PR TITLE
Prevent ambiguous path overrides in batch adds

### DIFF
--- a/src/man/kiwix-manage.1
+++ b/src/man/kiwix-manage.1
@@ -43,8 +43,12 @@ Remove the given \fBZIM_ID\fR from \fBLIBRARY_FILE\fR. At least one \fBZIM_ID\fR
 Show given \fBZIM_ID\fP from \fBLIBRARY_FILE\fR. If no \fBZIM_ID\fP is given then all contents from \fBLIBRARY_FILE\fR are shown.
 
 .SH OPTIONS
-.TP
+.PP
 Options to be used with the action \fBadd\fR:
+.PP
+When \fB\-\-url\fR or \fB\-\-zimPathToSave\fR is used, exactly one
+\fBZIM_PATH\fR must be supplied. Add files separately to set a custom value
+for each ZIM.
 
 .TP
 \fB\-\-url=HTTP_URL\fR

--- a/src/man/kiwix-manage.1
+++ b/src/man/kiwix-manage.1
@@ -42,6 +42,10 @@ Show given \fBZIM_ID\fP from \fBLIBRARY_FILE\fR. If no \fBZIM_ID\fP is given the
 .SH OPTIONS
 .TP
 Options to be used with the action \fBadd\fR:
+.PP
+When \fB\-\-url\fR or \fB\-\-zimPathToSave\fR is used, exactly one
+\fBZIM_PATH\fR must be supplied. Add files separately to set a custom value
+for each ZIM.
 
 .TP
 \fB\-\-url=HTTP_URL\fR

--- a/src/manager/kiwix-manage.cpp
+++ b/src/manager/kiwix-manage.cpp
@@ -73,8 +73,8 @@ Arguments:
 
 Options:
   Custom options for "add" action:
-    --zimPathToSave=<custom_zim_path>  Replace the current ZIM file path
-    --url=<http_zim_url>               Create an "url" attribute for the online version of the ZIM file
+    --zimPathToSave=<custom_zim_path>  Replace the current ZIM file path (single ZIM only)
+    --url=<http_zim_url>               Create an "url" attribute for the online version of a single ZIM file
 
   Other options:
     -h --help                          Print this help
@@ -114,16 +114,23 @@ int handle_add(kiwix::LibraryPtr library, const std::string& libraryPath,
   string zimPathToSave;
   string url;
 
-  kiwix::Manager manager(library);
-
   auto zimPaths = options.at("ZIMPATH").asStringList();
+  const bool hasCustomPath = options.at("--zimPathToSave").isString();
+  const bool hasUrl = options.at("--url").isString();
+  if (zimPaths.size() > 1 && (hasCustomPath || hasUrl)) {
+    std::cerr << "Cannot use --zimPathToSave or --url when adding multiple ZIM files. "
+              << "Add each ZIM separately to set a custom path or URL." << std::endl;
+    return 1;
+  }
+
+  kiwix::Manager manager(library);
   for (auto& zimPath: zimPaths) {
-    if (options.at("--zimPathToSave").isString()) {
+    if (hasCustomPath) {
       zimPathToSave = options.at("--zimPathToSave").asString();
     } else {
       zimPathToSave = zimPath;
     }
-    if (options.at("--url").isString()) {
+    if (hasUrl) {
       url = options.at("--url").asString();
     }
 

--- a/src/manager/kiwix-manage.cpp
+++ b/src/manager/kiwix-manage.cpp
@@ -75,8 +75,8 @@ Arguments:
 
 Options:
   Custom options for "add" action:
-    --zimPathToSave=<custom_zim_path>  Replace the current ZIM file path
-    --url=<http_zim_url>               Create an "url" attribute for the online version of the ZIM file
+    --zimPathToSave=<custom_zim_path>  Replace the current ZIM file path (single ZIM only)
+    --url=<http_zim_url>               Create an "url" attribute for the online version of a single ZIM file
 
   Other options:
     -h --help                          Print this help
@@ -110,6 +110,14 @@ int handle_show(const kiwix::Library& library, const std::string& libraryPath,
   return(0);
 }
 
+static bool hasAmbiguousAddOptions(const Options& options)
+{
+  const auto zimPaths = options.at("ZIMPATH").asStringList();
+  const bool hasCustomPath = static_cast<bool>(options.at("--zimPathToSave"));
+  const bool hasUrl = static_cast<bool>(options.at("--url"));
+  return zimPaths.size() > 1 && (hasCustomPath || hasUrl);
+}
+
 int handle_add(kiwix::Manager& manager, const std::string& libraryPath,
                 const Options& options)
 {
@@ -117,13 +125,16 @@ int handle_add(kiwix::Manager& manager, const std::string& libraryPath,
   string url;
 
   auto zimPaths = options.at("ZIMPATH").asStringList();
+  const bool hasCustomPath = static_cast<bool>(options.at("--zimPathToSave"));
+  const bool hasUrl = static_cast<bool>(options.at("--url"));
+
   for (auto& zimPath: zimPaths) {
-    if (options.at("--zimPathToSave").isString()) {
+    if (hasCustomPath) {
       zimPathToSave = options.at("--zimPathToSave").asString();
     } else {
       zimPathToSave = zimPath;
     }
-    if (options.at("--url").isString()) {
+    if (hasUrl) {
       url = options.at("--url").asString();
     }
 
@@ -203,6 +214,12 @@ int main(int argc, char** argv)
     action = SHOW;
   else if (args.at("remove").asBool() || args.at("delete").asBool())
     action = REMOVE;
+
+  if (action == ADD && hasAmbiguousAddOptions(args)) {
+    std::cerr << "Cannot use --zimPathToSave or --url when adding multiple ZIM files. "
+              << "Add each ZIM separately to set a custom path or URL." << std::endl;
+    return 1;
+  }
 
   /* Try to read the file */
   libraryPath = kiwix::isRelativePath(libraryPath)


### PR DESCRIPTION
## Summary

- reject `--zimPathToSave` or `--url` when more than one ZIM path is supplied
- fail before constructing the manager or adding any books, so the library is left untouched
- document the single-ZIM constraint in both `--help` and the man page

## Rationale

Each override option carries exactly one value. Reusing that value across a batch creates multiple book entries that point to the same path or URL. Rejecting the ambiguous combination prevents library corruption while preserving valid batch adds without overrides and valid single-ZIM overrides.

## Validation

- `git diff --check`
- verified the rejection occurs before any `addBookFromPathAndGetId` call or library rewrite
- Windows and Linux compilation delegated to the upstream CI matrix because the local host does not have libkiwix/libzim

Fixes #835